### PR TITLE
Refactor to not run etlas during evaluation phase

### DIFF
--- a/src/main/groovy/com/typelead/gradle/eta/plugins/EtaPlugin.java
+++ b/src/main/groovy/com/typelead/gradle/eta/plugins/EtaPlugin.java
@@ -2,7 +2,7 @@ package com.typelead.gradle.eta.plugins;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
 
 /**
  * A {@link Plugin} which sets up an Eta project.
@@ -15,6 +15,7 @@ public class EtaPlugin implements Plugin<Project> {
     public static final String TASK_GROUP_NAME = "EtaPlugin";
     public static final String CLEAN_ETA_TASK_NAME = "cleanEta";
     public static final String COMPILE_ETA_TASK_NAME = "compileEta";
+    public static final String RUNTIME_ETA_TASK_NAME = "runtimeEta";
     public static final String RUN_ETA_TASK_NAME = "runEta";
     public static final String TEST_DEPS_ETA_TASK_NAME = "installTestDepsEta";
     public static final String TEST_COMPILE_ETA_TASK_NAME = "testCompileEta";
@@ -30,6 +31,6 @@ public class EtaPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(EtaBasePlugin.class);
-        project.getPluginManager().apply(BasePlugin.class);
+        project.getPluginManager().apply(JavaPlugin.class);
     }
 }

--- a/src/main/groovy/com/typelead/gradle/eta/tasks/EtaCompile.java
+++ b/src/main/groovy/com/typelead/gradle/eta/tasks/EtaCompile.java
@@ -11,6 +11,8 @@ public class EtaCompile extends AbstractEtlasTask {
     @TaskAction
     public void compileEta() {
         EtlasCommand c = new EtlasCommand(this);
+        c.maybeInitSandbox();
+        c.installDependenciesOnly();
         if (!getConfigureFlags().isEmpty()) c.configure(getConfigureFlags());
         c.build();
     }

--- a/src/main/groovy/com/typelead/gradle/eta/tasks/EtaRuntime.java
+++ b/src/main/groovy/com/typelead/gradle/eta/tasks/EtaRuntime.java
@@ -1,0 +1,26 @@
+package com.typelead.gradle.eta.tasks;
+
+import com.typelead.gradle.eta.plugins.EtaPlugin;
+import com.typelead.gradle.utils.EtlasCommand;
+import org.gradle.api.tasks.TaskAction;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class EtaRuntime extends AbstractEtlasTask {
+
+    @TaskAction
+    public void runtimeEta() {
+        getRuntimeDependencies().forEach(it -> {
+                getLogger().info("Adding runtimeEta dependency: " + it);
+                getProject().getDependencies().add(
+                        EtaPlugin.ETA_RUNTIME_CONFIGURATION_NAME,
+                        getProject().files(it)
+                );
+        });
+    }
+
+    private Set<String> getRuntimeDependencies() {
+        return new HashSet<>(new EtlasCommand(this).depsClasspath());
+    }
+}

--- a/src/main/groovy/com/typelead/gradle/eta/tasks/EtaTest.java
+++ b/src/main/groovy/com/typelead/gradle/eta/tasks/EtaTest.java
@@ -14,7 +14,6 @@ public class EtaTest extends AbstractEtlasTask {
     @TaskAction
     public void testEta() {
         EtlasCommand c = new EtlasCommand(this);
-        c.enableTests();
         c.test(getTestFlags());
     }
 

--- a/src/main/groovy/com/typelead/gradle/eta/tasks/EtaTestCompile.java
+++ b/src/main/groovy/com/typelead/gradle/eta/tasks/EtaTestCompile.java
@@ -11,6 +11,8 @@ public class EtaTestCompile extends AbstractEtlasTask {
     @TaskAction
     public void testCompileEta() {
         EtlasCommand c = new EtlasCommand(this);
+        c.maybeInitSandbox();
+        c.installTestDependenciesOnly();
         c.enableTests();
         c.build();
     }

--- a/src/main/groovy/com/typelead/gradle/utils/CabalInfo.java
+++ b/src/main/groovy/com/typelead/gradle/utils/CabalInfo.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/test/resources/testData/run2/build.gradle
+++ b/src/test/resources/testData/run2/build.gradle
@@ -12,10 +12,10 @@ task foo(type: EtaRun) {
     component = "foo"
 }
 
-foo.dependsOn(':compileEta')
+foo.dependsOn(':compileEta', ':runtimeEta')
 
 task bar(type: EtaRun) {
     component = "bar"
 }
 
-bar.dependsOn(':compileEta')
+bar.dependsOn(':compileEta', ':runtimeEta')


### PR DESCRIPTION
This is an attempt to move etlas calls out of the evaluation phase of gradle. Etlas is still called in `EtlasBinaryDependencyCache#putBinaryForVersion` to properly initialize after an initial download; however, even this can probably be moved into a task dependency.

This gets us closer to #1 also in that this paves the way to be able to specify `maven-depends` in the `build.gradle` instead of the cabal file.