### PR TITLE
Bump up eta and etlas versions of examples

### DIFF
--- a/examples/multi/build.gradle
+++ b/examples/multi/build.gradle
@@ -10,8 +10,8 @@ allprojects {
 }
 
 eta {
-    version = '0.7.2b1'
-    etlasVersion = '1.3.0.0'
+    version = '0.8.0b2'
+    etlasVersion = '1.4.0.0'
 }
 
 dependencies {

--- a/examples/simple/build.gradle
+++ b/examples/simple/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 eta {
-    version = '0.7.2b1'
-    etlasVersion = '1.3.0.0'
+    version = '0.8.0b2'
+    etlasVersion = '1.4.0.0'
 }
 
 sourceSets {

--- a/examples/test/build.gradle
+++ b/examples/test/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 eta {
-    version = '0.7.2b1'
-    etlasVersion = '1.3.0.0'
+    version = '0.8.0b2'
+    etlasVersion = '1.4.0.0'
 }
 
 dependencies {


### PR DESCRIPTION
@rahulmutt  Maybe the configuration for the eta block could be unified? Instead `version` and `useSystemEta` we can use (in a similar way `etlas select`works):

```groovy
version = 'x.y.z'
version = 'latest' 
version = 'system' 
```