### PR TITLE
Fix wrong project path in README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,4 @@ This folder contains examples you can use as reference when writing build script
 
 - [simple](./simple) - Demonstrates how to configure some basic options in an Eta project.
 - [fatjar](./fatjar) - Demonstrates how to configure the Shadow plugin to build a standalone JAR file that contains all the dependencies for the project.
-- [multi](./fatjar) - Demonstrates how to setup a non-trivial multi-module build involving both Eta and Java projects.
+- [multi](./multi) - Demonstrates how to setup a non-trivial multi-module build involving both Eta and Java projects.


### PR DESCRIPTION
As the title, the link **multi** just linked to a wrong path.