### PR TITLE
Make explicit the call to apply plugin in the "Source installation" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ buildscript {
     }
   }
 }
+
+apply plugin: 'com.typelead.eta'
+// apply plugin: 'com.typelead.eta.base'
+// apply plugin: 'com.typelead.eta.android'
 ```
 
 ## Quick Start


### PR DESCRIPTION
It is necessary to use `apply plugin` to use the version build from source (it doesn't work within `plugin {  }`)